### PR TITLE
extensions: Give priority to local environment

### DIFF
--- a/snapcraft/extensions/gnome.py
+++ b/snapcraft/extensions/gnome.py
@@ -141,15 +141,16 @@ class GNOME(Extension):
 
         return {
             "build-environment": [
-                {"PATH": f"/snap/{sdk_snap}/current/usr/bin:$PATH"},
+                {"PATH": f"$PATH:/snap/{sdk_snap}/current/usr/bin"},
                 {
                     "XDG_DATA_DIRS": (
-                        f"$SNAPCRAFT_STAGE/usr/share:/snap/{sdk_snap}"
-                        "/current/usr/share:/usr/share:$XDG_DATA_DIRS"
+                        "$XDG_DATA_DIRS:$SNAPCRAFT_STAGE/usr/share:"
+                        f"/snap/{sdk_snap}/current/usr/share:/usr/share"
                     )
                 },
                 {
-                    "LD_LIBRARY_PATH": ":".join(
+                    "LD_LIBRARY_PATH": "${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}"
+                    + ":".join(
                         [
                             f"/snap/{sdk_snap}/current/lib/$CRAFT_ARCH_TRIPLET",
                             f"/snap/{sdk_snap}/current/usr/lib/$CRAFT_ARCH_TRIPLET",
@@ -158,19 +159,19 @@ class GNOME(Extension):
                             f"/snap/{sdk_snap}/current/usr/lib/$CRAFT_ARCH_TRIPLET/pulseaudio",
                         ]
                     )
-                    + "${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
                 },
                 {
                     "PKG_CONFIG_PATH": (
+                        "$PKG_CONFIG_PATH:"
                         f"/snap/{sdk_snap}/current/usr/lib/$CRAFT_ARCH_TRIPLET/pkgconfig:"
                         f"/snap/{sdk_snap}/current/usr/lib/pkgconfig:"
-                        f"/snap/{sdk_snap}/current/usr/share/pkgconfig:$PKG_CONFIG_PATH"
+                        f"/snap/{sdk_snap}/current/usr/share/pkgconfig"
                     )
                 },
                 {
                     "GETTEXTDATADIRS": (
-                        f"/snap/{sdk_snap}/current/usr/share/gettext-current:"
-                        "$GETTEXTDATADIRS"
+                        "$GETTEXTDATADIRS:"
+                        f"/snap/{sdk_snap}/current/usr/share/gettext-current"
                     )
                 },
                 {
@@ -181,18 +182,18 @@ class GNOME(Extension):
                 },
                 {
                     "ACLOCAL_PATH": (
+                        "${ACLOCAL_PATH:+$ACLOCAL_PATH:}"
                         f"/snap/{sdk_snap}/current/usr/share/aclocal"
-                        "${ACLOCAL_PATH:+:$ACLOCAL_PATH}"
                     )
                 },
                 {
-                    "PYTHONPATH": ":".join(
+                    "PYTHONPATH": "${PYTHONPATH:+$PYTHONPATH:}"
+                    + ":".join(
                         [
                             f"/snap/{sdk_snap}/current/usr/lib/python3.10",
                             f"/snap/{sdk_snap}/current/usr/lib/python3/dist-packages",
                         ]
                     )
-                    + "${PYTHONPATH:+:$PYTHONPATH}"
                 },
             ]
         }

--- a/tests/unit/extensions/test_gnome.py
+++ b/tests/unit/extensions/test_gnome.py
@@ -102,15 +102,16 @@ def test_get_root_snippet(gnome_extension):
 def test_get_part_snippet(gnome_extension):
     assert gnome_extension.get_part_snippet() == {
         "build-environment": [
-            {"PATH": "/snap/gnome-42-2204-sdk/current/usr/bin:$PATH"},
+            {"PATH": "$PATH:/snap/gnome-42-2204-sdk/current/usr/bin"},
             {
                 "XDG_DATA_DIRS": (
-                    "$SNAPCRAFT_STAGE/usr/share:/snap/gnome-42-2204-sdk"
-                    "/current/usr/share:/usr/share:$XDG_DATA_DIRS"
+                    "$XDG_DATA_DIRS:$SNAPCRAFT_STAGE/usr/share:/snap/gnome-42-2204-sdk"
+                    "/current/usr/share:/usr/share"
                 )
             },
             {
-                "LD_LIBRARY_PATH": ":".join(
+                "LD_LIBRARY_PATH": "${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}"
+                + ":".join(
                     [
                         "/snap/gnome-42-2204-sdk/current/lib/$CRAFT_ARCH_TRIPLET",
                         "/snap/gnome-42-2204-sdk/current/usr/lib/$CRAFT_ARCH_TRIPLET",
@@ -119,19 +120,19 @@ def test_get_part_snippet(gnome_extension):
                         "/snap/gnome-42-2204-sdk/current/usr/lib/$CRAFT_ARCH_TRIPLET/pulseaudio",
                     ]
                 )
-                + "${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
             },
             {
                 "PKG_CONFIG_PATH": (
+                    "$PKG_CONFIG_PATH:"
                     "/snap/gnome-42-2204-sdk/current/usr/lib/$CRAFT_ARCH_TRIPLET/pkgconfig:"
                     "/snap/gnome-42-2204-sdk/current/usr/lib/pkgconfig:"
-                    "/snap/gnome-42-2204-sdk/current/usr/share/pkgconfig:$PKG_CONFIG_PATH"
+                    "/snap/gnome-42-2204-sdk/current/usr/share/pkgconfig"
                 )
             },
             {
                 "GETTEXTDATADIRS": (
-                    "/snap/gnome-42-2204-sdk/current/usr/share/gettext-current:"
-                    "$GETTEXTDATADIRS"
+                    "$GETTEXTDATADIRS:"
+                    "/snap/gnome-42-2204-sdk/current/usr/share/gettext-current"
                 )
             },
             {
@@ -142,18 +143,18 @@ def test_get_part_snippet(gnome_extension):
             },
             {
                 "ACLOCAL_PATH": (
+                    "${ACLOCAL_PATH:+$ACLOCAL_PATH:}"
                     "/snap/gnome-42-2204-sdk/current/usr/share/aclocal"
-                    "${ACLOCAL_PATH:+:$ACLOCAL_PATH}"
                 )
             },
             {
-                "PYTHONPATH": ":".join(
+                "PYTHONPATH": "${PYTHONPATH:+$PYTHONPATH:}"
+                + ":".join(
                     [
                         "/snap/gnome-42-2204-sdk/current/usr/lib/python3.10",
                         "/snap/gnome-42-2204-sdk/current/usr/lib/python3/dist-packages",
                     ]
                 )
-                + "${PYTHONPATH:+:$PYTHONPATH}"
             },
         ]
     }


### PR DESCRIPTION
When creating the environment for gnome shell, the order in which the variables from the SDK should be added was reversed: the SDK ones should be at the end, and the new elements should be at the beginning. This allows to priorityze the local changes over the generic elements in the SDK.
    
This was commented in Mattermost.


- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint`?
- [ ] Have you successfully run `pytest tests/unit`?

-----
